### PR TITLE
Add additional properties for upcoming shabbat+yomtov, zmanim, & more

### DIFF
--- a/hdate/date.py
+++ b/hdate/date.py
@@ -285,7 +285,8 @@ class HDate(BaseClass):
         itself.
         """
         day_iter = self
-        while day_iter.previous_day.holiday_type == HolidayTypes.YOM_TOV:
+        while (day_iter.previous_day.is_yom_tov or
+               day_iter.previous_day.is_shabbat):
             day_iter = day_iter.previous_day
         return day_iter
 
@@ -300,8 +301,7 @@ class HDate(BaseClass):
         itself.
         """
         day_iter = self
-        while (day_iter.next_day.holiday_type == HolidayTypes.YOM_TOV
-               or day_iter.next_day.is_shabbat):
+        while day_iter.next_day.is_yom_tov or day_iter.next_day.is_shabbat:
             day_iter = day_iter.next_day
         return day_iter
 

--- a/hdate/date.py
+++ b/hdate/date.py
@@ -18,6 +18,7 @@ from hdate.common import BaseClass, HebrewDate
 from hdate.htables import HolidayTypes, Months
 
 _LOGGER = logging.getLogger(__name__)
+# pylint: disable=too-many-public-methods
 
 
 class HDate(BaseClass):
@@ -158,10 +159,11 @@ class HDate(BaseClass):
 
     @property
     def is_shabbat(self):
-        """Return True if this date is Shabbat, specifically Saturday .
+        """Return True if this date is Shabbat, specifically Saturday.
 
         Returns False on Friday because the HDate object has no notion of time.
-        For more detailed nuance, use the Zmanim object."""
+        For more detailed nuance, use the Zmanim object.
+        """
         return self.gdate.weekday() == 5
 
     @property
@@ -268,7 +270,7 @@ class HDate(BaseClass):
         if self.is_shabbat or self.is_yom_tov:
             return self
 
-        if self.upcoming_yom_tov <  self.upcoming_shabbat:
+        if self.upcoming_yom_tov < self.upcoming_shabbat:
             return self.upcoming_yom_tov
         return self.upcoming_shabbat
 
@@ -279,7 +281,8 @@ class HDate(BaseClass):
         This is useful for three-day holidays, for example: it will return the
         first in a string of Yom Tov + Shabbat.
         If this HDate is Shabbat followed by no Yom Tov, returns the Saturday.
-        If this HDate is neither Yom Tov, nor Shabbat, this just returns itself.
+        If this HDate is neither Yom Tov, nor Shabbat, this just returns
+        itself.
         """
         day_iter = self
         while day_iter.previous_day.holiday_type == HolidayTypes.YOM_TOV:
@@ -293,7 +296,8 @@ class HDate(BaseClass):
         This is useful for three-day holidays, for example: it will return the
         last in a string of Yom Tov + Shabbat.
         If this HDate is Shabbat followed by no Yom Tov, returns the Saturday.
-        If this HDate is neither Yom Tov, nor Shabbat, this just returns itself.
+        If this HDate is neither Yom Tov, nor Shabbat, this just returns
+        itself.
         """
         day_iter = self
         while (day_iter.next_day.holiday_type == HolidayTypes.YOM_TOV

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -71,25 +71,20 @@ class Zmanim(BaseClass):
     @property
     def candle_lighting(self):
         """Return the time for candle lighting, or None if not applicable."""
-        today_holiday_type = HDate(
-            gdate=self.date, diaspora=self.location.diaspora).holiday_type
+        today = HDate(gdate=self.date, diaspora=self.location.diaspora)
 
-        tomorrow = self.date + dt.timedelta(days=1)
-        tomorrow_holiday_type = HDate(
-            gdate=tomorrow, diaspora=self.location.diaspora).holiday_type
+        tomorrow = HDate(gdate=self.date + dt.timedelta(days=1),
+                                      diaspora=self.location.diaspora)
 
         # If today is a Yom Tov or Shabbat, and tomorrow is a Yom Tov or
         # Shabbat return the havdalah time as the candle lighting time.
-        if ((today_holiday_type == HolidayTypes.YOM_TOV
-             or self.date.weekday() == 5)
-                and (tomorrow_holiday_type == HolidayTypes.YOM_TOV
-                     or tomorrow.weekday() == 5)):
+        if ((today.is_yom_tov or today.is_shabbat)
+                and (tomorrow.is_yom_tov or tomorrow.is_shabbat)):
             return self._havdalah_datetime
 
         # Otherwise, if today is Friday or erev Yom Tov, return candle
         # lighting.
-        if (self.date.weekday() == 4
-                or tomorrow_holiday_type == HolidayTypes.YOM_TOV):
+        if tomorrow.is_shabbat or tomorrow.is_yom_tov:
             return (self.zmanim["sunset"]
                     - dt.timedelta(minutes=self.candle_lighting_offset))
         return None
@@ -113,20 +108,16 @@ class Zmanim(BaseClass):
         after today, the havdalah value is defined to be None (to avoid
         misleading the user that melacha is permitted).
         """
-        today_holiday_type = HDate(
-            gdate=self.date, diaspora=self.location.diaspora).holiday_type
-        tomorrow = self.date + dt.timedelta(days=1)
-        tomorrow_holiday_type = HDate(
-            gdate=tomorrow, diaspora=self.location.diaspora).holiday_type
+        today = HDate(gdate=self.date, diaspora=self.location.diaspora)
+        tomorrow = HDate(gdate=self.date + dt.timedelta(days=1),
+                         diaspora=self.location.diaspora)
 
         # If today is Yom Tov or Shabbat, and tomorrow is Yom Tov or Shabbat,
         # then there is no havdalah value for today. Technically, there is
         # havdalah mikodesh l'kodesh, but that is represented in the
         # candle_lighting value to avoid misuse of the havdalah API.
-        if (self.date.weekday() == 5
-                or today_holiday_type == HolidayTypes.YOM_TOV):
-            if (tomorrow.weekday() == 5
-                    or tomorrow_holiday_type == HolidayTypes.YOM_TOV):
+        if today.is_shabbat or today.is_yom_tov:
+            if tomorrow.is_shabbat  or tomorrow.is_yom_tov:
                 return None
             return self._havdalah_datetime
         return None

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -23,11 +23,12 @@ class Zmanim(BaseClass):
     """Return Jewish day times."""
 
     def __init__(self, date=dt.datetime.now(), location=Location(),
-                 hebrew=True, shabbat_offset=18):
+                 hebrew=True, candle_lighting_offset=18, havdalah_offset=0):
         """Initialize the Zmanim object."""
         self.location = location
         self.hebrew = hebrew
-        self.shabbat_offset = shabbat_offset
+        self.candle_lighting_offset = candle_lighting_offset
+        self.havdalah_offset = havdalah_offset
 
         if isinstance(date, dt.datetime):
             self.date = date.date()
@@ -58,6 +59,51 @@ class Zmanim(BaseClass):
                 key, value in self.get_utc_sun_time_full().items()}
 
     @property
+    def candle_lighting(self):
+        """Returns the time for candle lighting, or None if not applicable."""
+        # TODO: set candle lighting properly for two-day Yom Tov.
+        today_holiday_type = HDate(
+            gdate=self.date, diaspora=self.location.diaspora).holiday_type
+
+        tomorrow = self.date + dt.timedelta(days=1)
+        tomorrow_holiday_type = HDate(
+            gdate=tomorrow, diaspora=self.location.diaspora).holiday_type
+
+        # If today is a Yom Tov or Shabbat, and tomorrow is a Yom Tov or Shabbat
+        # return the havdalah time as the candle lighting time.
+        if ((today_holiday_type == HolidayTypes.YOM_TOV 
+              or self.date.weekday() == 5)
+            and (tomorrow_holiday_type == HolidayTypes.YOM_TOV
+                 or tomorrow.weekday() == 5)):
+            return self.havdalah
+
+        # Otherwise, if today is Friday or erev Yom Tov, return candle lighting.
+        if (self.date.weekday() == 4 
+            or tomorrow_holiday_type == HolidayTypes.YOM_TOV):
+            return (self.zmanim["sunset"]
+                    - dt.timedelta(minutes=self.candle_lighting_offset))
+        return None
+
+    @property
+    def havdalah(self):
+        """Returns the time for havdalah, or None if not applicable.
+
+        If havdalah_offset is 0, uses the time for three_stars. Otherwise,
+        adds the offset to the time of sunset and uses that.
+        """
+        today_holiday_type = HDate(
+            gdate=self.date, diaspora=self.location.diaspora).holiday_type
+
+        if (self.date.weekday() == 5 
+            or today_holiday_type == HolidayTypes.YOM_TOV):
+            if self.havdalah_offset == 0:
+              return self.zmanim["three_stars"]
+            else:
+              return (self.zmanim["sunset"]
+                      + dt.timedelta(minutes=self.havdalah_offset))
+        return None
+
+    @property
     def issur_melacha_in_effect(self):
         """At the given time, return whether issur melacha is in effect."""
         weekday = self.date.weekday()
@@ -69,7 +115,7 @@ class Zmanim(BaseClass):
 
         if weekday == 4 or tomorrow_holiday_type == HolidayTypes.YOM_TOV:
             if self.time > (self.zmanim["sunset"] -
-                            dt.timedelta(minutes=self.shabbat_offset)):
+                            dt.timedelta(minutes=self.candle_lighting_offset)):
                 return True
         if weekday == 5 or today_holiday_type == HolidayTypes.YOM_TOV:
             if self.time < self.zmanim["three_stars"]:

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -22,6 +22,7 @@ from hdate.htables import HolidayTypes
 class Zmanim(BaseClass):
     """Return Jewish day times."""
 
+    # pylint: disable=too-many-arguments
     def __init__(self, date=dt.datetime.now(), location=Location(),
                  hebrew=True, candle_lighting_offset=18, havdalah_offset=0):
         """Initialize the Zmanim object."""
@@ -60,8 +61,7 @@ class Zmanim(BaseClass):
 
     @property
     def candle_lighting(self):
-        """Returns the time for candle lighting, or None if not applicable."""
-        # TODO: set candle lighting properly for two-day Yom Tov.
+        """Return the time for candle lighting, or None if not applicable."""
         today_holiday_type = HDate(
             gdate=self.date, diaspora=self.location.diaspora).holiday_type
 
@@ -69,24 +69,25 @@ class Zmanim(BaseClass):
         tomorrow_holiday_type = HDate(
             gdate=tomorrow, diaspora=self.location.diaspora).holiday_type
 
-        # If today is a Yom Tov or Shabbat, and tomorrow is a Yom Tov or Shabbat
-        # return the havdalah time as the candle lighting time.
-        if ((today_holiday_type == HolidayTypes.YOM_TOV 
-              or self.date.weekday() == 5)
-            and (tomorrow_holiday_type == HolidayTypes.YOM_TOV
-                 or tomorrow.weekday() == 5)):
+        # If today is a Yom Tov or Shabbat, and tomorrow is a Yom Tov or
+        # Shabbat return the havdalah time as the candle lighting time.
+        if ((today_holiday_type == HolidayTypes.YOM_TOV
+             or self.date.weekday() == 5)
+                and (tomorrow_holiday_type == HolidayTypes.YOM_TOV
+                     or tomorrow.weekday() == 5)):
             return self.havdalah
 
-        # Otherwise, if today is Friday or erev Yom Tov, return candle lighting.
-        if (self.date.weekday() == 4 
-            or tomorrow_holiday_type == HolidayTypes.YOM_TOV):
+        # Otherwise, if today is Friday or erev Yom Tov, return candle
+        # lighting.
+        if (self.date.weekday() == 4
+                or tomorrow_holiday_type == HolidayTypes.YOM_TOV):
             return (self.zmanim["sunset"]
                     - dt.timedelta(minutes=self.candle_lighting_offset))
         return None
 
     @property
     def havdalah(self):
-        """Returns the time for havdalah, or None if not applicable.
+        """Return the time for havdalah, or None if not applicable.
 
         If havdalah_offset is 0, uses the time for three_stars. Otherwise,
         adds the offset to the time of sunset and uses that.
@@ -94,13 +95,13 @@ class Zmanim(BaseClass):
         today_holiday_type = HDate(
             gdate=self.date, diaspora=self.location.diaspora).holiday_type
 
-        if (self.date.weekday() == 5 
-            or today_holiday_type == HolidayTypes.YOM_TOV):
+        if (self.date.weekday() == 5
+                or today_holiday_type == HolidayTypes.YOM_TOV):
             if self.havdalah_offset == 0:
-              return self.zmanim["three_stars"]
-            else:
-              return (self.zmanim["sunset"]
-                      + dt.timedelta(minutes=self.havdalah_offset))
+                return self.zmanim["three_stars"]
+            # Otherwise, use the offset.
+            return (self.zmanim["sunset"]
+                    + dt.timedelta(minutes=self.havdalah_offset))
         return None
 
     @property

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -134,17 +134,7 @@ class Zmanim(BaseClass):
     @property
     def issur_melacha_in_effect(self):
         """At the given time, return whether issur melacha is in effect."""
-        # if self.candle_lighting is not None and self.havdalah is not None:
-        # return self.time <
-        # today = HDate(gdate=self.date, diaspora=self.location.diaspora)
-        # last_day = Zmanim(date=today.last_day.gdate, location=self.location,
-        # candle_lighting_offset=self.candle_lighting_offset,
-        # havdalah_offset=self.havdalah_offset)
-        # if last_day.havdalah is not None:
-        # return self.time < last_day.havdalah
-
-        # if self.candle_lighting is not None:
-        # return self.time > self.candle_lighting
+        # TODO: Rewrite this in terms of candle_lighting/havdalah properties.
         weekday = self.date.weekday()
         tomorrow = self.date + dt.timedelta(days=1)
         tomorrow_holiday_type = HDate(

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -203,6 +203,7 @@ class TestSpecialDays(object):
         ((2017, 10, 4), False, {"start": (2017, 10, 5), "end": (2017, 10, 5)}),
         ((2017, 10, 6), True, {"start": (2017, 10, 5), "end": (2017, 10, 7)}),
         ((2017, 10, 6), False, {"start": (2017, 10, 7), "end": (2017, 10, 7)}),
+        ((2016, 6, 12), True, {"start": (2016, 6, 11), "end": (2016, 6, 13)})
     ]
 
     @pytest.mark.parametrize('current_date, diaspora, dates',

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -259,7 +259,8 @@ class TestSpecialDays(object):
         # In case of yom hazikaron and yom ha'atsmaut don't test for the
         # case of 0 between 5708 and 5764
         if years[0] != 5000:
-            if years[0] == 5764 and holiday in [17, 25]:
+            if (years[0] == 5764 
+                and holiday in ['yom_hazikaron', 'yom_haatzmaut']):
                 return
             year = random.randint(5000, years[0] - 1)
             print("Testing " + holiday + " for " + str(year))

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -259,7 +259,7 @@ class TestSpecialDays(object):
         # In case of yom hazikaron and yom ha'atsmaut don't test for the
         # case of 0 between 5708 and 5764
         if years[0] != 5000:
-            if (years[0] == 5764 
+            if (years[0] == 5764
                 and holiday in ['yom_hazikaron', 'yom_haatzmaut']):
                 return
             year = random.randint(5000, years[0] - 1)

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -204,14 +204,15 @@ class TestSpecialDays(object):
         ((2017, 10, 6), True, {"start": (2017, 10, 5), "end": (2017, 10, 7)}),
         ((2017, 10, 6), False, {"start": (2017, 10, 7), "end": (2017, 10, 7)}),
     ]
+
     @pytest.mark.parametrize('current_date, diaspora, dates',
                              UPCOMING_SHABBAT_OR_YOM_TOV)
     def test_get_next_shabbat_or_yom_tov(self, current_date, diaspora,
                                          dates):
         hd = HDate(gdate=datetime.date(*current_date), diaspora=diaspora)
-        assert (hd.upcoming_shabbat_or_yom_tov.first_day.gdate 
+        assert (hd.upcoming_shabbat_or_yom_tov.first_day.gdate
                 == datetime.date(*dates["start"]))
-        assert (hd.upcoming_shabbat_or_yom_tov.last_day.gdate 
+        assert (hd.upcoming_shabbat_or_yom_tov.last_day.gdate
                 == datetime.date(*dates["end"]))
 
     @pytest.mark.parametrize('date, holiday', NON_MOVING_HOLIDAYS)

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -187,6 +187,33 @@ class TestSpecialDays(object):
             next_yom_tov = hdate.upcoming_yom_tov
             assert next_yom_tov.gdate == datetime.date(*holiday_date)
 
+    UPCOMING_SHABBAT_OR_YOM_TOV = [
+        ((2018, 9, 8), True, {"start": (2018, 9, 8), "end": (2018, 9, 8)}),
+        ((2018, 9, 9), True, {"start": (2018, 9, 10), "end": (2018, 9, 11)}),
+        ((2018, 9, 16), True, {"start": (2018, 9, 19), "end": (2018, 9, 19)}),
+        ((2018, 9, 24), True, {"start": (2018, 9, 24), "end": (2018, 9, 25)}),
+        ((2018, 9, 25), True, {"start": (2018, 9, 24), "end": (2018, 9, 25)}),
+        ((2018, 9, 24), False, {"start": (2018, 9, 24), "end": (2018, 9, 24)}),
+        ((2018, 9, 24), True, {"start": (2018, 9, 24), "end": (2018, 9, 25)}),
+        ((2018, 3, 30), True, {"start": (2018, 3, 31), "end": (2018, 4, 1)}),
+        ((2018, 3, 30), False, {"start": (2018, 3, 31), "end": (2018, 3, 31)}),
+        ((2017, 9, 22), True, {"start": (2017, 9, 21), "end": (2017, 9, 23)}),
+        ((2017, 9, 22), False, {"start": (2017, 9, 21), "end": (2017, 9, 23)}),
+        ((2017, 10, 4), True, {"start": (2017, 10, 5), "end": (2017, 10, 7)}),
+        ((2017, 10, 4), False, {"start": (2017, 10, 5), "end": (2017, 10, 5)}),
+        ((2017, 10, 6), True, {"start": (2017, 10, 5), "end": (2017, 10, 7)}),
+        ((2017, 10, 6), False, {"start": (2017, 10, 7), "end": (2017, 10, 7)}),
+    ]
+    @pytest.mark.parametrize('current_date, diaspora, dates',
+                             UPCOMING_SHABBAT_OR_YOM_TOV)
+    def test_get_next_shabbat_or_yom_tov(self, current_date, diaspora,
+                                         dates):
+        hd = HDate(gdate=datetime.date(*current_date), diaspora=diaspora)
+        assert (hd.upcoming_shabbat_or_yom_tov.first_day.gdate 
+                == datetime.date(*dates["start"]))
+        assert (hd.upcoming_shabbat_or_yom_tov.last_day.gdate 
+                == datetime.date(*dates["end"]))
+
     @pytest.mark.parametrize('date, holiday', NON_MOVING_HOLIDAYS)
     def test_get_holidays_non_moving(self, rand_hdate, date, holiday):
         rand_hdate.hdate = HebrewDate(rand_hdate.hdate.year, date[1], date[0])

--- a/tests/test_hdate.py
+++ b/tests/test_hdate.py
@@ -260,7 +260,7 @@ class TestSpecialDays(object):
         # case of 0 between 5708 and 5764
         if years[0] != 5000:
             if (years[0] == 5764
-                and holiday in ['yom_hazikaron', 'yom_haatzmaut']):
+                    and holiday in ['yom_hazikaron', 'yom_haatzmaut']):
                 return
             year = random.randint(5000, years[0] - 1)
             print("Testing " + holiday + " for " + str(year))

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -75,6 +75,7 @@ class TestZmanim(object):
         (dt(2018, 9, 9, 19, 30), 18, dt(2018, 9, 9, 19, 1), True),
         # Candle lighting matches the time that would be havdalah.
         (dt(2018, 9, 10, 8, 1), 18, dt(2018, 9, 10, 19, 59), True),
+        (dt(2018, 9, 10, 20, 20), 18, dt(2018, 9, 10, 19, 59), True),
     ]
 
     @pytest.mark.parametrize(["now", "offset", "candle_lighting",

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -1,7 +1,7 @@
 import datetime
-from datetime import datetime as dt
 import random
 from calendar import isleap
+from datetime import datetime as dt
 
 import pytest
 from dateutil import tz
@@ -14,6 +14,7 @@ from hdate.common import Location
 
 NYC_LAT = 40.7128
 NYC_LNG = -74.0060
+
 
 class TestZmanim(object):
 
@@ -75,15 +76,17 @@ class TestZmanim(object):
         # This is not desirable behavior; CL should match havdalah.
         (dt(2018, 9, 10, 8, 1), 18, dt(2018, 9, 10, 19, 59), True),
     ]
+
     @pytest.mark.parametrize(["now", "offset", "candle_lighting",
                               "melacha_assur"], CANDLES_TEST)
-    def test_candle_lighting(self, now, offset, candle_lighting, melacha_assur):
+    def test_candle_lighting(self, now, offset, candle_lighting,
+                             melacha_assur):
         location_tz_str = Location(
             name="New York", latitude=NYC_LAT, longitude=NYC_LNG,
             timezone="America/New_York", diaspora=True)
         # Use a constant offset for Havdalah for unit test stability.
         zmanim = Zmanim(date=now, location=location_tz_str,
-            candle_lighting_offset=offset, havdalah_offset=42)
+                        candle_lighting_offset=offset, havdalah_offset=42)
         actual = zmanim.candle_lighting
         if actual is not None:
             actual = actual.replace(tzinfo=None)
@@ -102,6 +105,7 @@ class TestZmanim(object):
         (dt(2018, 9, 11, 16, 1), 0, dt(2018, 9, 11, 19, 57), True),
         (dt(2018, 9, 10, 8, 1), 0, dt(2018, 9, 10, 19, 58), True),
     ]
+
     @pytest.mark.parametrize(["now", "offset", "havdalah", "melacha_assur"],
                              HAVDALAH_TEST)
     def test_havdalah(self, now, offset, havdalah, melacha_assur):
@@ -110,10 +114,9 @@ class TestZmanim(object):
             timezone="America/New_York", diaspora=True)
         # Use a constant offset for Havdalah for unit test stability.
         zmanim = Zmanim(date=now, location=location_tz_str,
-            havdalah_offset=offset)
+                        havdalah_offset=offset)
         actual = zmanim.havdalah
         if actual is not None:
             actual = actual.replace(tzinfo=None)
         assert actual == havdalah
         assert zmanim.issur_melacha_in_effect == melacha_assur
-

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -73,7 +73,7 @@ class TestZmanim(object):
         (dt(2018, 9, 19, 22, 1), 18, None, False),
         (dt(2018, 9, 9, 16, 1), 20, dt(2018, 9, 9, 18, 59), False),
         (dt(2018, 9, 9, 19, 30), 18, dt(2018, 9, 9, 19, 1), True),
-        # This is not desirable behavior; CL should match havdalah.
+        # Candle lighting matches the time that would be havdalah.
         (dt(2018, 9, 10, 8, 1), 18, dt(2018, 9, 10, 19, 59), True),
     ]
 
@@ -103,7 +103,9 @@ class TestZmanim(object):
         (dt(2018, 9, 9, 16, 1), 0, None, False),
         (dt(2018, 9, 9, 19, 30), 0, None, True),
         (dt(2018, 9, 11, 16, 1), 0, dt(2018, 9, 11, 19, 57), True),
-        (dt(2018, 9, 10, 8, 1), 0, dt(2018, 9, 10, 19, 58), True),
+        # No havdalah in the middle of Yom Tov.
+        (dt(2018, 9, 10, 8, 1), 0, None, True),
+        (dt(2018, 9, 10, 20, 20), 0, None, True),
     ]
 
     @pytest.mark.parametrize(["now", "offset", "havdalah", "melacha_assur"],

--- a/tests/test_zmanim.py
+++ b/tests/test_zmanim.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import datetime as dt
 import random
 from calendar import isleap
 
@@ -11,6 +12,8 @@ from hdate.common import Location
 # pylint: disable=no-self-use
 # pylint-comment: In tests, classes are just a grouping semantic
 
+NYC_LAT = 40.7128
+NYC_LNG = -74.0060
 
 class TestZmanim(object):
 
@@ -47,10 +50,10 @@ class TestZmanim(object):
         timezone_str = "America/New_York"
         timezone = tz.gettz(timezone_str)
         location_tz_str = Location(
-            name="New York", latitude=40.7128, longitude=-74.0060,
+            name="New York", latitude=NYC_LAT, longitude=NYC_LNG,
             timezone=timezone_str, diaspora=True)
         location = Location(
-            name="New York", latitude=40.7128, longitude=-74.0060,
+            name="New York", latitude=NYC_LAT, longitude=NYC_LNG,
             timezone=timezone, diaspora=True)
 
         assert (Zmanim(
@@ -60,3 +63,57 @@ class TestZmanim(object):
         assert (Zmanim(
             date=day, location=location)
             .zmanim["first_stars"].time() == datetime.time(19, 48))
+
+    # Times are assumed for NYC.
+    CANDLES_TEST = [
+        (dt(2018, 9, 7, 13, 1), 18, dt(2018, 9, 7, 19, 4), False),
+        (dt(2018, 9, 7, 20, 1), 18, dt(2018, 9, 7, 19, 4), True),
+        (dt(2018, 9, 8, 13, 1), 18, None, True),
+        (dt(2018, 9, 19, 22, 1), 18, None, False),
+        (dt(2018, 9, 9, 16, 1), 20, dt(2018, 9, 9, 18, 59), False),
+        (dt(2018, 9, 9, 19, 30), 18, dt(2018, 9, 9, 19, 1), True),
+        # This is not desirable behavior; CL should match havdalah.
+        (dt(2018, 9, 10, 8, 1), 18, dt(2018, 9, 10, 19, 59), True),
+    ]
+    @pytest.mark.parametrize(["now", "offset", "candle_lighting",
+                              "melacha_assur"], CANDLES_TEST)
+    def test_candle_lighting(self, now, offset, candle_lighting, melacha_assur):
+        location_tz_str = Location(
+            name="New York", latitude=NYC_LAT, longitude=NYC_LNG,
+            timezone="America/New_York", diaspora=True)
+        # Use a constant offset for Havdalah for unit test stability.
+        zmanim = Zmanim(date=now, location=location_tz_str,
+            candle_lighting_offset=offset, havdalah_offset=42)
+        actual = zmanim.candle_lighting
+        if actual is not None:
+            actual = actual.replace(tzinfo=None)
+        assert actual == candle_lighting
+        assert zmanim.issur_melacha_in_effect == melacha_assur
+
+    # Times are assumed for NYC.
+    HAVDALAH_TEST = [
+        (dt(2018, 9, 7, 13, 1), 42, None, False),
+        (dt(2018, 9, 7, 20, 1), 42, None, True),
+        (dt(2018, 9, 8, 13, 1), 42, dt(2018, 9, 8, 20, 2), True),
+        (dt(2018, 9, 8, 13, 1), 0, dt(2018, 9, 8, 20, 2), True),
+        (dt(2018, 9, 19, 22, 1), 18, dt(2018, 9, 19, 19, 20), False),
+        (dt(2018, 9, 9, 16, 1), 0, None, False),
+        (dt(2018, 9, 9, 19, 30), 0, None, True),
+        (dt(2018, 9, 11, 16, 1), 0, dt(2018, 9, 11, 19, 57), True),
+        (dt(2018, 9, 10, 8, 1), 0, dt(2018, 9, 10, 19, 58), True),
+    ]
+    @pytest.mark.parametrize(["now", "offset", "havdalah", "melacha_assur"],
+                             HAVDALAH_TEST)
+    def test_havdalah(self, now, offset, havdalah, melacha_assur):
+        location_tz_str = Location(
+            name="New York", latitude=NYC_LAT, longitude=NYC_LNG,
+            timezone="America/New_York", diaspora=True)
+        # Use a constant offset for Havdalah for unit test stability.
+        zmanim = Zmanim(date=now, location=location_tz_str,
+            havdalah_offset=offset)
+        actual = zmanim.havdalah
+        if actual is not None:
+            actual = actual.replace(tzinfo=None)
+        assert actual == havdalah
+        assert zmanim.issur_melacha_in_effect == melacha_assur
+


### PR DESCRIPTION
Adds new properties for HA integration:
- upcoming_shabbat_or_yom_tov
- first_day / last_day for multi-day yom tov
- candle_lighting/havdalah

Also now correctly handles multi-day yom tov scenarios. Library now is more consistent when providing candles/havdalah times by following the philosophy of only reporting one of those times if an action should be taken. For example, on day 2 of a 3-day yom tov, havdalah (i.e. regular kodesh l'chol) is not recited that night, so no value is returned to avoid confusion (ignores kodesh l'kodesh). However, candle lighting time IS provided at that time to indicate that candles should be lit (and kodesh l'kodesh havdalah should be recited).