### PR TITLE
Add function to get the current hdate based on datetime

### DIFF
--- a/hdate/__init__.py
+++ b/hdate/__init__.py
@@ -2,11 +2,33 @@
 Jewish calendrical date and times for a given location.
 
 HDate calculates and generates a represantation either in English or Hebrew
-of the Jewish calendrical date and times for a given location
+of the Jewish calendrical date and times for a given location.
 """
+from datetime import timedelta
 from hdate.common import HebrewDate, Location
 from hdate.date import HDate
 from hdate.htables import HolidayTypes
 from hdate.zmanim import Zmanim
 
 __all__ = ['HDate', 'Zmanim', 'HebrewDate', 'Location', 'HolidayTypes']
+
+def get_hdate_for_datetime(now, diaspora, hebrew, location, 
+                           candle_lighting_offset, havdalah_offset):
+    """Gets the HDate for a given datetime; switches after tzeit."""
+    today = now.date()
+    date = HDate(today, diaspora=diaspora, hebrew=hebrew)
+
+    times = Zmanim(
+        date=now, location=location,
+        candle_lighting_offset=candle_lighting_offset,
+        havdalah_offset=havdalah_offset, hebrew=hebrew)
+
+    tzeit = times.zmanim['three_stars']
+    # In case the havdalah offset is later than the calculated three stars,
+    # use the later time.
+    if times.havdalah is not None:
+      tzeit = max(tzeit, times.havdalah)
+    if (now >= tzeit):
+      today += timedelta(1)
+      date = HDate(today, diaspora=diaspora, hebrew=hebrew)
+    return date

--- a/hdate/__init__.py
+++ b/hdate/__init__.py
@@ -12,9 +12,10 @@ from hdate.zmanim import Zmanim
 
 __all__ = ['HDate', 'Zmanim', 'HebrewDate', 'Location', 'HolidayTypes']
 
-def get_hdate_for_datetime(now, diaspora, hebrew, location, 
+
+def get_hdate_for_datetime(now, diaspora, hebrew, location,
                            candle_lighting_offset, havdalah_offset):
-    """Gets the HDate for a given datetime; switches after tzeit."""
+    """Get the HDate for a given datetime; switches after tzeit."""
     today = now.date()
     date = HDate(today, diaspora=diaspora, hebrew=hebrew)
 
@@ -27,8 +28,8 @@ def get_hdate_for_datetime(now, diaspora, hebrew, location,
     # In case the havdalah offset is later than the calculated three stars,
     # use the later time.
     if times.havdalah is not None:
-      tzeit = max(tzeit, times.havdalah)
-    if (now >= tzeit):
-      today += timedelta(1)
-      date = HDate(today, diaspora=diaspora, hebrew=hebrew)
+        tzeit = max(tzeit, times.havdalah)
+    if now >= tzeit:
+        today += timedelta(1)
+        date = HDate(today, diaspora=diaspora, hebrew=hebrew)
     return date

--- a/hdate/zmanim.py
+++ b/hdate/zmanim.py
@@ -74,7 +74,7 @@ class Zmanim(BaseClass):
         today = HDate(gdate=self.date, diaspora=self.location.diaspora)
 
         tomorrow = HDate(gdate=self.date + dt.timedelta(days=1),
-                                      diaspora=self.location.diaspora)
+                         diaspora=self.location.diaspora)
 
         # If today is a Yom Tov or Shabbat, and tomorrow is a Yom Tov or
         # Shabbat return the havdalah time as the candle lighting time.
@@ -117,7 +117,7 @@ class Zmanim(BaseClass):
         # havdalah mikodesh l'kodesh, but that is represented in the
         # candle_lighting value to avoid misuse of the havdalah API.
         if today.is_shabbat or today.is_yom_tov:
-            if tomorrow.is_shabbat  or tomorrow.is_yom_tov:
+            if tomorrow.is_shabbat or tomorrow.is_yom_tov:
                 return None
             return self._havdalah_datetime
         return None


### PR DESCRIPTION
Based on the bug in https://github.com/home-assistant/home-assistant/issues/20492 we should move the "switch" of Hebrew date to tzeit hakochavim (or havdalah, whichever is later) - this avoids switching to next week's havdalah before this week's havdalah has occurred.

This PR adds a function which encapsulates all of this, which HA will just use to get the "correct" date.